### PR TITLE
Change to only pickup beta and release builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
  mkdir -p \
 	/app/duplicati && \
  duplicati_tag=$(curl -sX GET "https://api.github.com/repos/duplicati/duplicati/releases" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
+	| awk '/tag_name.*(beta|release)/{print $4;exit}' FS='[""]') && \
  duplicati_zip="duplicati-${duplicati_tag#*-}.zip" && \
  curl -o \
  /tmp/duplicati.zip -L \


### PR DESCRIPTION
Currently duplicati has published first beta and so taking experimental
and canary releases probably no longer appropriate, perhaps a seperate
dockerfile for those might be worth it.

Proposed fix for issue #2 
closes #2