### PR TITLE
Allow for selecting 1 or more Duplicati release channels during build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM lsiobase/mono
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG CHANNEL="beta|release"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="sparklyballs"
 
@@ -10,11 +11,13 @@ LABEL maintainer="sparklyballs"
 ENV HOME="/config"
 
 RUN \
+ apt-get update && apt-get install -y git && \
  echo "**** install duplicati ****" && \
  mkdir -p \
-	/app/duplicati && \
- duplicati_tag=$(curl -sX GET "https://api.github.com/repos/duplicati/duplicati/releases" \
-	| awk '/tag_name.*(beta|release)/{print $4;exit}' FS='[""]') && \
+       /app/duplicati && \
+ duplicati_tag=$(git ls-remote --tags https://github.com/duplicati/duplicati/ | cut -f2 \
+       | sed 's/refs\/tags\/*//' | sort -V | grep '.*[^\{\}]$' | grep '^.*[^.*[^\{\}]$' \
+       | grep -E "$CHANNEL" | tail -n1) && \
  duplicati_zip="duplicati-${duplicati_tag#*-}.zip" && \
  curl -o \
  /tmp/duplicati.zip -L \


### PR DESCRIPTION
Used git to list tags instead of parsing full HTML.

I don't have access to `lsiobase/mono`, so adding `git` should probably occur there instead of in this Dockerfile.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

