### PR TITLE
Fix for host header sent by the client is not allowed

### DIFF
--- a/root/etc/services.d/duplicati/run
+++ b/root/etc/services.d/duplicati/run
@@ -4,4 +4,4 @@ cd /app/duplicati || exit
 
  exec \
 	s6-setuidgid abc mono Duplicati.Server.exe \
-	--webservice-interface=any --server-datafolder=/config
+	--webservice-interface=any --server-datafolder=/config --webservice-allowed-hostnames=*


### PR DESCRIPTION
 "*" is needed in the hostnames field on the settings menu in order for reverse proxy to work. The field is only shown when visited on 127.0.0.1. This is not possible when running it on a container. 

